### PR TITLE
feat: add docker-compose at local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@ lerna-debug.log*
 
 .env
 .env.local
+.env.test
+.env.dev
+.env.prod
+
+.envrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:17-alpine3.14 as app
+
+WORKDIR /usr/app
+EXPOSE 3000
+
+COPY tsconfig.json ./tsconfig.json
+COPY tsconfig.build.json ./tsconfig.build.json
+COPY nest-cli.json ./nest-cli.json
+COPY .env ./.env
+COPY package.json ./package.json
+COPY package-lock.json ./package-lock.json
+COPY src ./src
+
+RUN npm install
+RUN npm run build

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # Dijkstra server
+
+# Project required
+- docker, docker-compose
+
+# Getting started
+
+### .env 준비
+
+``` bash
+vi .env
+```
+`.env` 파일내용 
+``` bash
+FOO=bar
+```
+
+
+### local docker container환경 구성
+```
+# mysql 실행
+docker-compose up --build -d
+```
+- mysql은 localhost:23306 을 바라보면 됨

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.7'
+
+services:
+  dijkstra-mysql:
+    image: mysql:8.0.28
+    ports:
+      - '23306:3306'
+    container_name: dijkstra-mysql
+    environment:
+      - MYSQL_USER=user
+      - MYSQL_PASSWORD=password
+      - MYSQL_ROOT_PASSWORD=password
+      - MYSQL_DATABASE=dijkstra-test
+
+  dijkstra-app:
+    container_name: dijkstra-app
+    build:
+      dockerfile: Dockerfile
+      context: .
+    image: dijkstra/dijkstra-api
+    command: tail -f /dev/null
+    ports:
+      - "3000:3000"


### PR DESCRIPTION
# 연관 이슈 

#1 

# 작업내용

- docker-compose 추가
- gitignore에 .env 파일 가능성 있는것들 추가
- Dockerize 완료
- README.md에 내용 업데이트

# 결과물

- localhost:23306이 mysql 이니까 이걸 사용해서 작업하면 됩니다.
- [mysql workbench](https://dev.mysql.com/downloads/workbench/) 편하게 이용해서 작업하시면 됩니다.